### PR TITLE
Update loadType mapping.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=0.0.1-SNAPSHOT
+VERSION=0.0.2-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsen-dtvr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
@@ -90,11 +90,9 @@ public class NielsenDTVRIntegration extends Integration<AppSdk> {
         jsonMetadata.put("channelName", properties.getString("channel"));
 
       String load_type = "";
-      if (properties.containsKey("load_type"))
-        load_type = "load_type";
+      if (properties.containsKey("load_type")) load_type = "load_type";
 
-      if (properties.containsKey("loadType"))
-        load_type = "loadType";
+      if (properties.containsKey("loadType")) load_type = "loadType";
 
       if (!load_type.isEmpty())
         jsonMetadata.put("adModel", properties.getString(load_type).equals("dynamic") ? "2" : "1");

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
@@ -89,13 +89,13 @@ public class NielsenDTVRIntegration extends Integration<AppSdk> {
       if (properties.containsKey("channel"))
         jsonMetadata.put("channelName", properties.getString("channel"));
 
-      String load_type = "";
-      if (properties.containsKey("load_type")) load_type = "load_type";
+      String loadType = "";
+      if (properties.containsKey("load_type")) loadType = "load_type";
 
-      if (properties.containsKey("loadType")) load_type = "loadType";
+      if (properties.containsKey("loadType")) loadType = "loadType";
 
-      if (!load_type.isEmpty())
-        jsonMetadata.put("adModel", properties.getString(load_type).equals("dynamic") ? "2" : "1");
+      if (!loadType.isEmpty())
+        jsonMetadata.put("adModel", properties.getString(loadType).equals("dynamic") ? "2" : "1");
 
     } catch (JSONException e) {
       logger.error(e, "Failed to send loadMetadata event");

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
@@ -89,8 +89,15 @@ public class NielsenDTVRIntegration extends Integration<AppSdk> {
       if (properties.containsKey("channel"))
         jsonMetadata.put("channelName", properties.getString("channel"));
 
+      String load_type = "";
       if (properties.containsKey("load_type"))
-        jsonMetadata.put("adModel", properties.getString("load_type").equals("linear") ? "1" : "2");
+        load_type = "load_type";
+
+      if (properties.containsKey("loadType"))
+        load_type = "loadType";
+
+      if (!load_type.isEmpty())
+        jsonMetadata.put("adModel", properties.getString(load_type).equals("dynamic") ? "2" : "1");
 
     } catch (JSONException e) {
       logger.error(e, "Failed to send loadMetadata event");

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
@@ -107,7 +107,7 @@ class NielsenDTVRIntegrationFactory implements Integration.Factory {
   JSONObject parseAppSdkConfig(ValueMap settings) throws JSONException {
     JSONObject appSdkConfig = new JSONObject();
     String sfcode = settings.getString(SETTING_SF_CODE_KEY);
-    if (sfcode == null) {
+    if (sfcode.isEmpty()) {
       sfcode = "us";
     }
     appSdkConfig.put("appid", settings.getString(SETTING_APP_ID_KEY)).put("sfcode", sfcode);

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
@@ -106,9 +106,11 @@ class NielsenDTVRIntegrationFactory implements Integration.Factory {
    */
   JSONObject parseAppSdkConfig(ValueMap settings) throws JSONException {
     JSONObject appSdkConfig = new JSONObject();
-    appSdkConfig
-        .put("appid", settings.getString(SETTING_APP_ID_KEY))
-        .put("sfcode", settings.getString(SETTING_SF_CODE_KEY));
+    String sfcode = settings.getString(SETTING_SF_CODE_KEY);
+    if (sfcode == null) {
+      sfcode = "us";
+    }
+    appSdkConfig.put("appid", settings.getString(SETTING_APP_ID_KEY)).put("sfcode", sfcode);
 
     if (settings.getBoolean(SETTING_DEBUG_KEY, false)) {
       appSdkConfig.put("nol_devDebug", "DEBUG");

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
@@ -52,7 +52,7 @@ public class NielsenDTVRIntegrationFactoryTest {
     private NielsenDTVRIntegrationFactory factory;
 
     private final String appid = "testappid";
-    private final String sfcode = "testsfcode";
+    private final String sfcode = "";
 
     @Before
     public void init() {
@@ -79,7 +79,7 @@ public class NielsenDTVRIntegrationFactoryTest {
     public void parseAppSdkConfig() throws JSONException {
         JSONObject expectedConfig = new JSONObject()
                 .put("appid", appid)
-                .put("sfcode", sfcode);
+                .put("sfcode", "us");
 
         JSONAssert.assertEquals(expectedConfig, factory.parseAppSdkConfig(settings), JSONCompareMode.STRICT);
 


### PR DESCRIPTION
I promise CI tests have passed: https://ci.segment.com/workflow-run/37bbb7e9-fdf5-4a84-9472-a819e42a6f99

**What does this PR do?**
This PR does two things:
- Updates logic to look for `load_type` AND `loadType`
- Falls back to `linear` loadType unless value is `dynamic`
- Defaults "sfcode" setting to "us" if not otherwise specified by the customer in their Segment settings UI.
- **Note: Will update changelog after this PR is merged to master.

**Are there breaking changes in this PR?**
- Yes, this change alters the default behavior of the logic - but this is desired/expected.

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
- n/a

**Any background context you want to provide?**
- This is a Fox request.

**Is there parity with the server-side/analytics.js integration (if applicable)?**
- Yes.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
- No.

**What are the relevant tickets?**
- n/a

**Link to CC ticket**
- None needed for mobile.


**List all the tests accounts you have used to make sure this change works**
- n/a

**Helpful Docs**
- n/a

**Version for this change**
- 0.0.2