### PR TITLE
Clean up `sfcode` setting.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=0.0.2-SNAPSHOT
+VERSION=0.0.3-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsen-dtvr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
@@ -106,10 +106,13 @@ class NielsenDTVRIntegrationFactory implements Integration.Factory {
    */
   JSONObject parseAppSdkConfig(ValueMap settings) throws JSONException {
     JSONObject appSdkConfig = new JSONObject();
-    String sfcode = settings.getString(SETTING_SF_CODE_KEY);
-    if (sfcode.isEmpty()) {
-      sfcode = "us";
+
+    String sfcode = "us";
+    if (settings.containsKey(SETTING_SF_CODE_KEY)
+        && !settings.getString(SETTING_SF_CODE_KEY).isEmpty()) {
+      sfcode = settings.getString(SETTING_SF_CODE_KEY);
     }
+
     appSdkConfig.put("appid", settings.getString(SETTING_APP_ID_KEY)).put("sfcode", sfcode);
 
     if (settings.getBoolean(SETTING_DEBUG_KEY, false)) {

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactory.java
@@ -109,6 +109,7 @@ class NielsenDTVRIntegrationFactory implements Integration.Factory {
 
     String sfcode = "us";
     if (settings.containsKey(SETTING_SF_CODE_KEY)
+        && settings.getString(SETTING_SF_CODE_KEY) != null
         && !settings.getString(SETTING_SF_CODE_KEY).isEmpty()) {
       sfcode = settings.getString(SETTING_SF_CODE_KEY);
     }

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
@@ -116,6 +116,39 @@ public class NielsenDTVRIntegrationFactoryTest {
     }
 
     @Test
+    public void sfcodeKeyMissing() throws JSONException {
+        settings.remove(SETTING_SF_CODE_KEY);
+
+        JSONObject expectedConfig = new JSONObject()
+                .put("appid", appid)
+                .put(SETTING_SF_CODE_KEY, "us");
+
+        JSONAssert.assertEquals(expectedConfig, factory.parseAppSdkConfig(settings), JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void emptySfCodeValue() throws JSONException {
+        settings.put(SETTING_SF_CODE_KEY, "");
+
+        JSONObject expectedConfig = new JSONObject()
+                .put("appid", appid)
+                .put("sfcode", sfcode);
+
+        JSONAssert.assertEquals(expectedConfig, factory.parseAppSdkConfig(settings), JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void nullSfCodeValue() throws JSONException {
+        settings.put(SETTING_SF_CODE_KEY, null);
+
+        JSONObject expectedConfig = new JSONObject()
+                .put("appid", appid)
+                .put("sfcode", sfcode);
+
+        JSONAssert.assertEquals(expectedConfig, factory.parseAppSdkConfig(settings), JSONCompareMode.STRICT);
+    }
+
+    @Test
     public void parseId3EventNames() {
         List<String> expected = Arrays.asList("sendid3a", "sendid3b");
         settings.put(SETTING_ID3_EVENTS_KEY, expected);

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
@@ -79,7 +79,7 @@ public class NielsenDTVRIntegrationFactoryTest {
     public void parseAppSdkConfig() throws JSONException {
         JSONObject expectedConfig = new JSONObject()
                 .put("appid", appid)
-                .put("sfcode", "us");
+                .put("sfcode", sfcode);
 
         JSONAssert.assertEquals(expectedConfig, factory.parseAppSdkConfig(settings), JSONCompareMode.STRICT);
 

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationFactoryTest.java
@@ -52,7 +52,7 @@ public class NielsenDTVRIntegrationFactoryTest {
     private NielsenDTVRIntegrationFactory factory;
 
     private final String appid = "testappid";
-    private final String sfcode = "";
+    private final String sfcode = "us";
 
     @Before
     public void init() {


### PR DESCRIPTION
**What does this PR do?**
- This PR cleans up some code that defaults the value of "sfcode" to "us".

**Are there breaking changes in this PR?**
-n/a

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
- n/a - but unit tests and build still work fine

**Any background context you want to provide?**
- Request from Nielsen.

**Is there parity with the server-side/analytics.js integration (if applicable)?**
- Yes, there will be.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
- n/a

**What are the relevant tickets?**
- n/a

**Link to CC ticket**
- n/a

**List all the tests accounts you have used to make sure this change works**
- n/a

**Helpful Docs**
- n/a

**Version for this change**
- n/a