### PR TITLE
update mapping for Video Playback Completed and add mapping for Video Playback Exited

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,14 +58,13 @@ jobs:
       - restore_cache:
                 key: dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
       - run:
-          name: Set up signature
+          name: Set up key ring file
           command: |
-              if [ "$SIGNATURE_SECRET" == "" ]; then {
+              if [ "$SIGNING_PRIVATE_KEY_BASE64" == "" ]; then {
                   echo "Invalid signature configuration"
                   exit 1
               } fi
-              base64 -d - <<< "$SIGNATURE_SECRET" > $SIGNATURE_SECRET_FILE
-              gpg --batch --yes --import $SIGNATURE_SECRET_FILE <<< $SIGNATURE_PASSWORD
+              echo $SIGNING_PRIVATE_KEY_BASE64 | base64 -d > $SIGNATURE_SECRET_FILE
       - run:
           name: Publish SNAPSHOT
           command: ./gradlew uploadArchives
@@ -83,14 +82,13 @@ jobs:
         - restore_cache:
                   key: dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
         - run:
-            name: Set up signature
+            name: Set up key ring file
             command: |
-                if [ "$SIGNATURE_SECRET" == "" ]; then {
+                if [ "$SIGNING_PRIVATE_KEY_BASE64" == "" ]; then {
                     echo "Invalid signature configuration"
                     exit 1
                 } fi
-                base64 -d - <<< "$SIGNATURE_SECRET" > $SIGNATURE_SECRET_FILE
-                gpg --batch --yes --import $SIGNATURE_SECRET_FILE <<< $SIGNATURE_PASSWORD
+                echo $SIGNING_PRIVATE_KEY_BASE64 | base64 -d > $SIGNATURE_SECRET_FILE
         - run:
             name: Verify tag
             command: |

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
 }
 
 // Use -Prelease or $ORG_GRADLE_PROJECT_RELEASE="true" to mark the project as a release
+if (!hasProperty('NIELSEN_USER') && !hasProperty('NIELSEN_AUTHCODE')) {
+    ext.NIELSEN_USER = System.getenv('NIELSEN_USER')
+    ext.NIELSEN_AUTHCODE = System.getenv('NIELSEN_AUTHCODE')
+}
 ext.isRelease = hasProperty('release')
 
 apply plugin: 'com.android.library'

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,11 @@ dependencies {
     testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.robolectric:robolectric:4.5'
     testImplementation 'org.mockito:mockito-core:2.28.0'
+    testImplementation 'net.bytebuddy:byte-buddy:1.9.10'
+    testImplementation 'org.objenesis:objenesis:3.0.1'
+    implementation group: 'androidx.lifecycle', name: 'lifecycle-common-java8', version: '2.3.0'
 
     // Required for local (non-android) testing
     testImplementation 'org.json:json:20180813'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=0.0.3-SNAPSHOT
+VERSION=0.0.4-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsen-dtvr
 POM_PACKAGING=jar

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -1,3 +1,12 @@
+if (!hasProperty('NIELSEN_USER') && !hasProperty('NIELSEN_AUTHCODE')) {
+    ext.NIELSEN_USER = System.getenv('NIELSEN_USER')
+    ext.NIELSEN_AUTHCODE = System.getenv('NIELSEN_AUTHCODE')
+}
+
+if (!hasProperty('SEGMENT_WRITE_KEY')) {
+    ext.SEGMENT_WRITE_KEY = System.getenv('SEGMENT_WRITE_KEY')
+}
+
 apply plugin: 'com.android.application'
 
 android {

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
@@ -47,10 +47,9 @@ public class NielsenDTVRIntegration extends Integration<AppSdk> {
       case "Video Content Completed":
       case "Video Playback Buffer Started":
       case "Video Playback Seek Started":
-        stop();
-        break;
+      case "Video Playback Exited":
       case "Video Playback Completed":
-        end();
+        stop();
         break;
       case "Application Backgrounded":
         stop();

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
@@ -47,6 +47,7 @@ public class NielsenDTVRIntegration extends Integration<AppSdk> {
       case "Video Content Completed":
       case "Video Playback Buffer Started":
       case "Video Playback Seek Started":
+      //Nielsen requested Video Playback Completed and new Video Playback Exited event map to stop as end is not used for DTVR
       case "Video Playback Exited":
       case "Video Playback Completed":
         stop();

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegration.java
@@ -47,7 +47,7 @@ public class NielsenDTVRIntegration extends Integration<AppSdk> {
       case "Video Content Completed":
       case "Video Playback Buffer Started":
       case "Video Playback Seek Started":
-      //Nielsen requested Video Playback Completed and new Video Playback Exited event map to stop as end is not used for DTVR
+        //Nielsen requested Video Playback Completed and new Video Playback Exited event map to stop as end is not used for DTVR
       case "Video Playback Exited":
       case "Video Playback Completed":
         stop();

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendtvr/NielsenDTVRIntegrationTest.java
@@ -182,13 +182,23 @@ public class NielsenDTVRIntegrationTest {
     }
 
     @Test
+    public void videoPlaybackExited() {
+        integration.track(
+                basePayloadBuilder
+                        .event("Video Playback Exited")
+                        .build());
+
+        verify(appSdk).stop();
+    }
+
+    @Test
     public void videoPlaybackCompleted() {
         integration.track(
                 basePayloadBuilder
                         .event("Video Playback Completed")
                         .build());
 
-        verify(appSdk).end();
+        verify(appSdk).stop();
     }
 
     @Test


### PR DESCRIPTION
**What does this PR do?**
Nielsen has requested we remove any mappings to `end` for DTVR. Instead, Video Playback Completed should be mapped to `stop`.

Additionally, Fox has requested a new event for Video Playback Exited be added to our spec. This has been approved by the spec committee. See here: https://paper.dropbox.com/doc/Video-Spec-Event-Proposal-for-Video-Playback-Exited--A8j5DFZuVoZYlsG~ZQr96tlcAg-rUDm4tQEB1RsdH0R7Xujm. Nielsen has recommended mapping this new event to their `stop` method as well for DTVR.

**Testing**
Unit tests are erroring out with the following message:

```org.mockito.exceptions.base.MockitoException:```
```Mockito cannot mock this class: class com.nielsen.app.sdk.AppSdk.```

<img width="1438" alt="Screen Shot 2021-01-28 at 9 17 58 PM" src="https://user-images.githubusercontent.com/49517136/106234850-b98e8780-61b6-11eb-9f6a-b9db6cd6db3d.png">

This error happens on the `master` branch as well so I wonder if the Nielsen AppSdk is a private and/or final class. Working on resolving unit tests and testing locally.

Changes being made for iOS and web as well. iOS PR here: https://github.com/segment-integrations/analytics-ios-integration-nielsen-dtvr/pull/12.